### PR TITLE
fix: replace broken awesome-prometheus-alerts link

### DIFF
--- a/docs/01.2021年/03.学习周刊-总第3期-2021年第20周.md
+++ b/docs/01.2021年/03.学习周刊-总第3期-2021年第20周.md
@@ -43,7 +43,7 @@ description:
 
 ----
 
-- 项目地址：[Awesome Prometheus alerts](https://awesome-prometheus-alerts.grep.to/)
+- 项目地址：[Awesome Prometheus alerts](https://samber.github.io/awesome-prometheus-alerts/)
 - 项目说明：开箱即用的prometheus告警规则合集。
 - 相关文章：[github地址](https://github.com/samber/awesome-prometheus-alerts)。
 


### PR DESCRIPTION
Hi!

The `awesome-prometheus-alerts.grep.to` domain is no longer maintained: the site is gone and the domain now shows a parking page, so the link in this repo is broken.

This PR replaces it with the current home of the project:

https://samber.github.io/awesome-prometheus-alerts

No other changes. Thanks!
